### PR TITLE
feat: add the latest posts from Alan's blog

### DIFF
--- a/.github/workflows/readme-updates.yml
+++ b/.github/workflows/readme-updates.yml
@@ -1,0 +1,18 @@
+name: README updates with the latest blog posts
+
+on:
+ schedule:
+   # Every hour at minute 0
+   - cron: '0 * * * *'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JasonEtco/rss-to-readme@v2
+        with:
+          feed-url: https://medium.com/feed/alan
+          readme-section: feed
+          empty-commits: 'false'
+          branch: acceptance
+          path: 'profile/README.md'

--- a/.github/workflows/readme-updates.yml
+++ b/.github/workflows/readme-updates.yml
@@ -2,8 +2,8 @@ name: README updates with the latest blog posts
 
 on:
  schedule:
-   # Every hour at minute 0
-   - cron: '0 * * * *'
+   # Every day at 00:00
+   - cron: '0 0 * * *'
 
 jobs:
   update:

--- a/profile/README.md
+++ b/profile/README.md
@@ -27,9 +27,9 @@ If you are interested in what we do as engineers or data scientists, check out o
 ### Latest posts 📖
 
 <!--START_SECTION:feed-->
+* [Scaling yourself in a hypergrowth company](https://medium.com/alan/scaling-yourself-in-a-hypergrowth-company-dfca20341682?source=rss----b2cb698c4e73---4)
 * [Fighting Impostor Syndrome](https://medium.com/alan/fighting-impostor-syndrome-392670406bbf?source=rss----b2cb698c4e73---4)
 * [Replacing the old with the new: Tale as old as time](https://medium.com/alan/replacing-the-old-with-the-new-tale-as-old-as-time-a3fcbd7fafce?source=rss----b2cb698c4e73---4)
 * [What we learned from a large refactoring](https://medium.com/alan/what-we-learned-from-a-large-refactoring-85291cb4457c?source=rss----b2cb698c4e73---4)
 * [Switching to a new tech stack](https://medium.com/alan/switching-to-a-new-tech-stack-170f1d9debaa?source=rss----b2cb698c4e73---4)
-* [How we do hackathons at Alan](https://medium.com/alan/how-we-do-hackathons-at-alan-b768eca01dda?source=rss----b2cb698c4e73---4)
 <!--END_SECTION:feed-->

--- a/profile/README.md
+++ b/profile/README.md
@@ -27,9 +27,9 @@ If you are interested in what we do as engineers or data scientists, check out o
 ### Latest posts 📖
 
 <!--START_SECTION:feed-->
+* [Fighting Impostor Syndrome](https://medium.com/alan/fighting-impostor-syndrome-392670406bbf?source=rss----b2cb698c4e73---4)
 * [Replacing the old with the new: Tale as old as time](https://medium.com/alan/replacing-the-old-with-the-new-tale-as-old-as-time-a3fcbd7fafce?source=rss----b2cb698c4e73---4)
 * [What we learned from a large refactoring](https://medium.com/alan/what-we-learned-from-a-large-refactoring-85291cb4457c?source=rss----b2cb698c4e73---4)
 * [Switching to a new tech stack](https://medium.com/alan/switching-to-a-new-tech-stack-170f1d9debaa?source=rss----b2cb698c4e73---4)
 * [How we do hackathons at Alan](https://medium.com/alan/how-we-do-hackathons-at-alan-b768eca01dda?source=rss----b2cb698c4e73---4)
-* [A Hackathon Story: Shorten Sales Negotiations with Linear Optimisation](https://medium.com/alan/a-hackathon-story-shorten-sales-negotiations-with-linear-optimisation-139959f0b6b3?source=rss----b2cb698c4e73---4)
 <!--END_SECTION:feed-->

--- a/profile/README.md
+++ b/profile/README.md
@@ -27,4 +27,9 @@ If you are interested in what we do as engineers or data scientists, check out o
 ### Latest posts 📖
 
 <!--START_SECTION:feed-->
+* [Replacing the old with the new: Tale as old as time](https://medium.com/alan/replacing-the-old-with-the-new-tale-as-old-as-time-a3fcbd7fafce?source=rss----b2cb698c4e73---4)
+* [What we learned from a large refactoring](https://medium.com/alan/what-we-learned-from-a-large-refactoring-85291cb4457c?source=rss----b2cb698c4e73---4)
+* [Switching to a new tech stack](https://medium.com/alan/switching-to-a-new-tech-stack-170f1d9debaa?source=rss----b2cb698c4e73---4)
+* [How we do hackathons at Alan](https://medium.com/alan/how-we-do-hackathons-at-alan-b768eca01dda?source=rss----b2cb698c4e73---4)
+* [A Hackathon Story: Shorten Sales Negotiations with Linear Optimisation](https://medium.com/alan/a-hackathon-story-shorten-sales-negotiations-with-linear-optimisation-139959f0b6b3?source=rss----b2cb698c4e73---4)
 <!--END_SECTION:feed-->

--- a/profile/README.md
+++ b/profile/README.md
@@ -21,3 +21,10 @@
 We are Alan. We help all people have a personalised and accessible healthcare experience.
 
 If you are interested in what we do as engineers or data scientists, check out our [blog](https://medium.com/alan) and [twitter](https://twitter.com/alanengineering).
+
+---
+
+### Latest posts 📖
+
+<!--START_SECTION:feed-->
+<!--END_SECTION:feed-->


### PR DESCRIPTION
Thanks to [JasonEtco/rss-to-readme](https://github.com/JasonEtco/rss-to-readme) GitHub Action, it's possible to add automatically latest posts from Alan's [blog](https://medium.com/alan).

---

This pull request:
* Runs every hour at minute 0.
* If there is a new blog post: updates the company README with the latest 5 (titles with direct links).

> 👉 Allows everyone to have an overview of new posts and in my opinion makes the README more engaging.