### PR TITLE
feat: show sponsorship program info & link to feedback form

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,30 +1,25 @@
-<!--
-
-**Here are some ideas to get you started:**
-
-🙋‍♀️ A short introduction - what is your organization all about?
-🌈 Contribution guidelines - how can the community get involved?
-👩‍💻 Useful resources - where can the community find your docs? Is there anything else the community should know?
-🍿 Fun facts - what does your team eat for breakfast?
-🧙 Remember, you can do mighty things with the power of [Markdown](https://guides.github.com/features/mastering-markdown/)
--->
-
 <img
   alt="Alan engineer"
   src="https://github.com/alan-eu/.github/raw/acceptance/profile/alan-eng-rounded.png"
-  width="200"
+  height="200"
   align="left"
 />
 
 ## Hi there 👋
 
-We are Alan. We help all people have a personalised and accessible healthcare experience.
+We are [Alan](https://about.alan.com). We're building the European personalised and accessible healthcare experience.
 
 If you are interested in what we do as engineers or data scientists, check out our [blog](https://medium.com/alan) and [twitter](https://twitter.com/alanengineering).
-
+  
 ---
 
-### Latest posts 📖
+<img height="10"/>
+
+<table>
+  <tr width="100%">
+    <td width="50%" valign="baseline">
+  
+#### Latest posts 📖
 
 <!--START_SECTION:feed-->
 * [Making a difference in order to save your mental health](https://medium.com/alan/making-a-difference-in-order-to-save-your-mental-health-75123b60e560?source=rss----b2cb698c4e73---4)
@@ -33,3 +28,17 @@ If you are interested in what we do as engineers or data scientists, check out o
 * [Machine Learning atAlan](https://medium.com/alan/machine-learning-atalan-e436e0ae721d?source=rss----b2cb698c4e73---4)
 * [Compose with temporal logic](https://medium.com/alan/compose-with-temporal-logic-e0b77b860b32?source=rss----b2cb698c4e73---4)
 <!--END_SECTION:feed-->
+
+</td>
+<td  width="50%" valign="baseline">
+      
+#### Sponsored by us? 💚
+
+<!-- todo: add sponsorship program link -->
+We regularly sponsor some open-source projects on GitHub as part of our Sponsorship Program.
+  
+You can get in touch and/or send feedback [here](https://forms.gle/YxxyJadt31w9RhXB6)!
+  
+  </td>
+  </tr>
+</table>


### PR DESCRIPTION
Closes OSS-11

Update our mission statement (I also updated the org display name & tagline), and add a quick link to the feedback form for maintainers we sponsor.

This is separate from [OSS-6](https://linear.app/alan-eu/issue/OSS-6/communicate-in-the-org-readme) which is about adding more in-depth information and links to our sponsorship program.
That'll will have to wait a bit as I finish the public documentation and we write a blog post/external announcement!

---

Before | After
------ | -----
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/24496417/175825702-10ae6bd1-2b7b-470c-90f0-5b072e05adf6.png"> | <img width="1099" alt="image" src="https://user-images.githubusercontent.com/24496417/175825689-9a7bdf52-3d26-4678-b495-0d226086663b.png">
